### PR TITLE
Fix hal_init name collision between arduino-esp32 and arduino-lmic

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,10 @@ build_flags =
     ; Select the power management chip
     -D AXP192=1
     ; -D AXP2101=1
+    ; hal_init is already used by arduino-esp32 (2.0), rename to LMIC_HAL_init
+    ; to avoid name collision.
+    ; https://github.com/mcci-catena/arduino-lmic/issues/714
+    -D hal_init=LMIC_HAL_init 
 deps_3rd_party =
     ESP8266 and ESP32 OLED driver for SSD1306 displays
     MCCI LoRaWAN LMIC library


### PR DESCRIPTION
The bug is tracked here: https://github.com/mcci-catena/arduino-lmic/issues/714

This pull request fixes the following linker failure when building using vscode, platformio on Linux. 

```
///.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/lib/libpp.a(hal_mac.o): in function `hal_init': (.text.hal_init+0xb4): multiple definition of `hal_init'; .pio/build/working-in-progress/libdad/libMCCI LoRaWAN LMIC library.a(hal.cpp.o):///git/g/hzgl-lora-communicator/.pio/libdeps/working-in-progress/MCCI LoRaWAN LMIC library/src/hal/hal.cpp:416: first defined here collect2: error: ld returned 1 exit status
*** [.pio/build/working-in-progress/firmware.elf] Error 1
```